### PR TITLE
Bugfix: decoded response is overridden

### DIFF
--- a/hybridauth/Hybrid/thirdparty/OAuth/OAuth2Client.php
+++ b/hybridauth/Hybrid/thirdparty/OAuth/OAuth2Client.php
@@ -141,7 +141,7 @@ class OAuth2Client
 		}
 
 		if( $response && $this->decode_json ){
-			$this->response = json_decode( $response );
+			return $this->response = json_decode( $response );
 		}
 
 		return $this->response;


### PR DESCRIPTION
Without this fix the response will never be returned as object but as json string instead.